### PR TITLE
Update license field of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "https://github.com/viskin/jquery-easing.git"
   },
-  "license": "LicenseRef-LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "jquery": "*"
   },


### PR DESCRIPTION
This tiny pull request updates the license field of package.json to confirm with recent changes in [npm@2.12.0](https://github.com/npm/npm/releases/tag/v2.12.0).

Sorry for the back-and-forth on the right "magic value" to use. I can't thank you enough for caring about licensing enough to review the npm package.json guidelines.
